### PR TITLE
Fix Fm.Parser in do-notation

### DIFF
--- a/lib/Fm.fm
+++ b/lib/Fm.fm
@@ -579,7 +579,7 @@ Fm.Parser.Core: Fm.Parser(Fm.Core)
 
 // Parses a definition
 Fm.Parser.Core.def: Fm.Parser(Pair(Fm.Name, Pair(Fm.Core, Fm.Core)))
-  do {
+  do Fm.Parser {
     var name = Fm.Parser.Core.name;
     Fm.Parser.text(":");
     var type = Fm.Parser.Core;


### PR DESCRIPTION
Looks like there was a missing `Fm.Parser` in the do-notation block